### PR TITLE
Use BitSet to streamline construction

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.lang.ref.SoftReference;
 import java.security.CodeSigner;
 import java.security.cert.Certificate;
+import java.util.BitSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
@@ -597,25 +598,14 @@ public class JarFile extends ZipFile {
     }
 
     private JarEntry getVersionedEntry(String name, JarEntry defaultEntry) {
-        if (!name.startsWith(META_INF)) {
-            int[] versions = JUZFA.getMetaInfVersions(this, name);
-            if (BASE_VERSION_FEATURE < versionFeature && versions.length > 0) {
-                // search for versioned entry
-                for (int i = versions.length - 1; i >= 0; i--) {
-                    int version = versions[i];
-                    // skip versions above versionFeature
-                    if (version > versionFeature) {
-                        continue;
-                    }
-                    // skip versions below base version
-                    if (version < BASE_VERSION_FEATURE) {
-                        break;
-                    }
-                    JarFileEntry vje = (JarFileEntry)super.getEntry(
-                            META_INF_VERSIONS + version + "/" + name);
-                    if (vje != null) {
-                        return vje.withBasename(name);
-                    }
+        if (BASE_VERSION_FEATURE < versionFeature && !name.startsWith(META_INF)) {
+            BitSet versions = JUZFA.getMetaInfVersions(this, name);
+            int version = versions.nextSetBit(BASE_VERSION_FEATURE);
+            while (version >= BASE_VERSION_FEATURE && version <= versionFeature) {
+                JarFileEntry vje = (JarFileEntry)super.getEntry(
+                        META_INF_VERSIONS + version + "/" + name);
+                if (vje != null) {
+                    return vje.withBasename(name);
                 }
             }
         }

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -600,13 +600,14 @@ public class JarFile extends ZipFile {
     private JarEntry getVersionedEntry(String name, JarEntry defaultEntry) {
         if (BASE_VERSION_FEATURE < versionFeature && !name.startsWith(META_INF)) {
             BitSet versions = JUZFA.getMetaInfVersions(this, name);
-            int version = versions.nextSetBit(BASE_VERSION_FEATURE);
-            while (version >= BASE_VERSION_FEATURE && version <= versionFeature) {
+            int version = versions.previousSetBit(versionFeature);
+            while (version >= BASE_VERSION_FEATURE) {
                 JarFileEntry vje = (JarFileEntry)super.getEntry(
                         META_INF_VERSIONS + version + "/" + name);
                 if (vje != null) {
                     return vje.withBasename(name);
                 }
+                version = versions.previousSetBit(version - 1);
             }
         }
         return defaultEntry;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1164,7 +1164,6 @@ public class ZipFile implements ZipConstants, Closeable {
         private static final int META_INF_LEN = 9;
         // "META-INF/versions//".length()
         private static final int META_INF_VERSIONS_LEN = 19;
-        private static final int[] EMPTY_META_VERSIONS = new int[0];
         // CEN size is limited to the maximum array size in the JDK
         private static final int MAX_CEN_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1081,12 +1081,14 @@ public class ZipFile implements ZipConstants, Closeable {
      * optimization when looking up potentially versioned entries.
      * Returns an empty array if no versioned entries exist.
      */
-    private int[] getMetaInfVersions(String name) {
+    private BitSet getMetaInfVersions(String name) {
         synchronized (this) {
             ensureOpen();
-            return res.zsrc.metaVersions.getOrDefault(name, Source.EMPTY_META_VERSIONS);
+            return res.zsrc.metaVersions.getOrDefault(name, EMPTY_VERSIONS);
         }
     }
+
+    private static final BitSet EMPTY_VERSIONS = new BitSet();
 
     /**
      * Returns the value of the System property which indicates whether the
@@ -1124,7 +1126,7 @@ public class ZipFile implements ZipConstants, Closeable {
                     return ((ZipFile)jar).getManifestName(onlyIfHasSignatureRelatedFiles);
                 }
                 @Override
-                public int[] getMetaInfVersions(JarFile jar, String name) {
+                public BitSet getMetaInfVersions(JarFile jar, String name) {
                     return ((ZipFile)jar).getMetaInfVersions(name);
                 }
                 @Override
@@ -1179,7 +1181,7 @@ public class ZipFile implements ZipConstants, Closeable {
         private int   manifestPos = -1;      // position of the META-INF/MANIFEST.MF, if exists
         private int   manifestNum = 0;       // number of META-INF/MANIFEST.MF, case insensitive
         private int[] signatureMetaNames;    // positions of signature related entries, if such exist
-        private Map<String, int[]> metaVersions; // Set of versions found in META-INF/versions/, by entry name
+        private Map<String, BitSet> metaVersions; // Set of versions found in META-INF/versions/, by entry name
         private final boolean startsWithLoc; // true, if ZIP file starts with LOCSIG (usually true)
 
         // A Hashmap for all entries.
@@ -1745,7 +1747,7 @@ public class ZipFile implements ZipConstants, Closeable {
             ArrayList<Integer> signatureNames = null;
             // Map entry name to the set of versions seen in
             // META-INF/versions/{version}/{name}
-            Map<String, Set<Integer>> metaVersionsMap = null;
+            Map<String, BitSet> metaVersionsMap = null;
 
             // Iterate through the entries in the central directory
             int idx = 0; // Index into the entries array
@@ -1790,7 +1792,7 @@ public class ZipFile implements ZipConstants, Closeable {
                             // Add version for name
                             if (metaVersionsMap == null)
                                 metaVersionsMap = new HashMap<>();
-                            metaVersionsMap.computeIfAbsent(name, n -> new HashSet<>()).add(version);
+                            metaVersionsMap.computeIfAbsent(name, _ -> new BitSet()).set(version);
                         }
                     }
                 }
@@ -1809,18 +1811,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 }
             }
             if (metaVersionsMap != null) {
-                metaVersions = new HashMap<>();
-                for (var entry : metaVersionsMap.entrySet()) {
-                    // Convert Set<Integer> to int[] for performance
-                    int[] versions = new int[entry.getValue().size()];
-                    int c = 0;
-                    for (Integer i : entry.getValue()) {
-                        versions[c++] = i.intValue();
-                    }
-                    // JarFile::getVersionedEntry expects sorted versions
-                    Arrays.sort(versions);
-                    metaVersions.put(entry.getKey(), versions);
-                }
+                metaVersions = metaVersionsMap;
             } else {
                 metaVersions = Map.of();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaUtilZipFileAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaUtilZipFileAccess.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.access;
 
+import java.util.BitSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
@@ -38,7 +39,7 @@ public interface JavaUtilZipFileAccess {
     public List<String> getManifestAndSignatureRelatedFiles(JarFile zip);
     public String getManifestName(JarFile zip, boolean onlyIfSignatureRelatedFiles);
     public int getManifestNum(JarFile zip);
-    public int[] getMetaInfVersions(JarFile zip, String name);
+    public BitSet getMetaInfVersions(JarFile zip, String name);
     public Enumeration<JarEntry> entries(ZipFile zip);
     public Stream<JarEntry> stream(ZipFile zip);
     public Stream<String> entryNameStream(ZipFile zip);


### PR DESCRIPTION
This is an alternative for https://github.com/openjdk/jdk/pull/21489 that removes need to sort and construct arrays inefficiently; instead the map built up in the initCEN pass can be used as-is, speeding up ZipFileOpen with hypothetical MR-heavy entries without noticeably different lookup performance compared to pull/21489 